### PR TITLE
Fixed memory leak

### DIFF
--- a/gdgifexporter/converter.gd
+++ b/gdgifexporter/converter.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 var _shader: Shader

--- a/gdgifexporter/gif-lzw/lsbbitpacker.gd
+++ b/gdgifexporter/gif-lzw/lsbbitpacker.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 class LSB_LZWBitPacker:

--- a/gdgifexporter/gif-lzw/lsbbitunpacker.gd
+++ b/gdgifexporter/gif-lzw/lsbbitunpacker.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 class LSB_LZWBitUnpacker:

--- a/gdgifexporter/gif-lzw/lzw.gd
+++ b/gdgifexporter/gif-lzw/lzw.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 var lsbbitpacker = preload('./lsbbitpacker.gd')

--- a/gdgifexporter/gifexporter.gd
+++ b/gdgifexporter/gifexporter.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 var little_endian = preload('./little_endian.gd').new()

--- a/gdgifexporter/little_endian.gd
+++ b/gdgifexporter/little_endian.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 func int_to_2bytes(value: int) -> PoolByteArray:

--- a/gdgifexporter/quantization/enhanced_uniform_quantization.gd
+++ b/gdgifexporter/quantization/enhanced_uniform_quantization.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 func how_many_divisions(colors_count: int) -> int:
 	return int(ceil( pow(colors_count, 1.0 / 4.0) ))

--- a/gdgifexporter/quantization/median_cut.gd
+++ b/gdgifexporter/quantization/median_cut.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 
 var converter = preload('../converter.gd').new()


### PR DESCRIPTION
Scripts now extend Reference instead of Node. This should fix a memory leak because there are no orphan nodes created. I tested the changes both in this repo and Pixelorama's and everything seems to be working as normal. Feel free to double check too.

Related commit: https://github.com/Orama-Interactive/Pixelorama/commit/1ff32f2892753dfb2886a0c7303f20bb4469326d