### PR TITLE
Workaround for Godot memory leak bug

### DIFF
--- a/gdgifexporter/quantization/median_cut.gd
+++ b/gdgifexporter/quantization/median_cut.gd
@@ -13,9 +13,10 @@ class TreeNode:
 	var average_color: Array
 	var axis: int
 	var median: int
-	var parent: TreeNode
-	var left: TreeNode
-	var right: TreeNode
+	# Comments is workaround for Godot memory leak bug
+	var parent#: TreeNode
+	var left#: TreeNode
+	var right#: TreeNode
 
 
 	func _init(_parent: TreeNode, _colors: Array):


### PR DESCRIPTION
Fixes https://github.com/jegor377/godot-gdgifexporter/issues/12

This is problem of Godot, not this project, but I think that is better to not cause memory leak(this project is used in Pixelorama, so it is really bad to see memory leak each time when opening this project)

I'm using 3.2.4.beta.custom_build. adfc646f8